### PR TITLE
Remove obsoleted option from local.json template

### DIFF
--- a/templates/local.json.erb
+++ b/templates/local.json.erb
@@ -1,5 +1,4 @@
 {
-  "storage.upload-size-limit": "10M",
   "config.ignore-issues": {
     "daemons.need-restarting": true,
     "security.security.alternate-file-domain": true


### PR DESCRIPTION
Phabricator reports that this option is no longer used, so remove
it from our configs.
